### PR TITLE
Fix CocoaPods/XCode metadata so project successfully builds

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,7 +25,7 @@ opt_in_rules:
 excluded:
   - Carthage
   - Pods
-  - Photo Assassin/Resources/Generated/R.generated.swift
+  - PhotoAssassin/Resources/Generated/R.generated.swift
 identifier_name:
   excluded:
     - id

--- a/PhotoAssassin.xcodeproj/project.pbxproj
+++ b/PhotoAssassin.xcodeproj/project.pbxproj
@@ -15,7 +15,9 @@
 		2A9222821F38797600A648E6 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9222811F38797600A648E6 /* ConfigurationManager.swift */; };
 		2ABEE6D41F38856A00531205 /* Configuration.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2ABEE6D31F38828A00531205 /* Configuration.plist */; };
 		2ABEE6D61F3886D700531205 /* RootRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABEE6D51F3886D700531205 /* RootRouter.swift */; };
+		453592BAE7D47041D989B3DA /* Pods_PhotoAssassinTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEE01467EB47FB4FBF4B858 /* Pods_PhotoAssassinTests.framework */; };
 		553FC23C214047CB001D9362 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553FC23B214047CB001D9362 /* R.generated.swift */; };
+		BCC899B854AFDB1D82FFE22D /* Pods_PhotoAssassin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 315972CCCCFF02A2AF2F368F /* Pods_PhotoAssassin.framework */; };
 		C90395241FC622D2006F1DC0 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90395231FC622D2006F1DC0 /* main.swift */; };
 		C90395261FC62399006F1DC0 /* TestsAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90395251FC62399006F1DC0 /* TestsAppDelegate.swift */; };
 		C90395271FC62425006F1DC0 /* TestsAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90395251FC62399006F1DC0 /* TestsAppDelegate.swift */; };
@@ -28,28 +30,36 @@
 			containerPortal = 2A1E772B1F384BFC006C84D4 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 2A1E77321F384BFC006C84D4;
-			remoteInfo = "Photo Assassin";
+			remoteInfo = PhotoAssassin;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		2A1DD4DE1F389C2200712195 /* DeeplinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkHandler.swift; sourceTree = "<group>"; };
 		2A1DD4E01F389E2100712195 /* NotificationsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsHandler.swift; sourceTree = "<group>"; };
-		2A1E77331F384BFC006C84D4 /* Photo Assassin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Photo Assassin.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A1E77331F384BFC006C84D4 /* PhotoAssassin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PhotoAssassin.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A1E77361F384BFC006C84D4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2A1E773D1F384BFD006C84D4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2A1E77401F384BFD006C84D4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		2A1E77421F384BFD006C84D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		2A1E77471F384BFD006C84D4 /* Photo AssassinTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Photo AssassinTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A1E77471F384BFD006C84D4 /* PhotoAssassinTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PhotoAssassinTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A1E774D1F384BFD006C84D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2A9222811F38797600A648E6 /* ConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
-		2A9222841F387B1D00A648E6 /* Photo AssassinTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Photo AssassinTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		2A9222841F387B1D00A648E6 /* PhotoAssassinTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PhotoAssassinTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		2ABEE6D31F38828A00531205 /* Configuration.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Configuration.plist; sourceTree = "<group>"; };
 		2ABEE6D51F3886D700531205 /* RootRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootRouter.swift; sourceTree = "<group>"; };
+		2C2BC69BEA45C045090EE25D /* Pods-PhotoAssassinTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PhotoAssassinTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PhotoAssassinTests/Pods-PhotoAssassinTests.release.xcconfig"; sourceTree = "<group>"; };
+		315972CCCCFF02A2AF2F368F /* Pods_PhotoAssassin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PhotoAssassin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		45AEA0686ECF05A538683431 /* Pods-PhotoAssassin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PhotoAssassin.release.xcconfig"; path = "Pods/Target Support Files/Pods-PhotoAssassin/Pods-PhotoAssassin.release.xcconfig"; sourceTree = "<group>"; };
 		553FC23B214047CB001D9362 /* R.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = "<group>"; };
 		55F50BE321404BDD00FAC039 /* Readme.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Readme.md; sourceTree = "<group>"; };
+		C52A4E7F78583ED8C2BBE440 /* Pods-PhotoAssassin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PhotoAssassin.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PhotoAssassin/Pods-PhotoAssassin.debug.xcconfig"; sourceTree = "<group>"; };
 		C90395231FC622D2006F1DC0 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C90395251FC62399006F1DC0 /* TestsAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestsAppDelegate.swift; sourceTree = "<group>"; };
+		CC236DEB12294412F387B307 /* Pods-PhotoAssassinTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PhotoAssassinTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PhotoAssassinTests/Pods-PhotoAssassinTests.debug.xcconfig"; sourceTree = "<group>"; };
+		CD5823A07B8C53621396FBF3 /* Pods-PhotoAssassinTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PhotoAssassinTests.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PhotoAssassinTests/Pods-PhotoAssassinTests.staging.xcconfig"; sourceTree = "<group>"; };
+		DCEE01467EB47FB4FBF4B858 /* Pods_PhotoAssassinTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PhotoAssassinTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE2B0C473DF0611EF21D8951 /* Pods-PhotoAssassin.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PhotoAssassin.staging.xcconfig"; path = "Pods/Target Support Files/Pods-PhotoAssassin/Pods-PhotoAssassin.staging.xcconfig"; sourceTree = "<group>"; };
 		FCB2C7CA1F57127800481080 /* Localizable.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -58,6 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCC899B854AFDB1D82FFE22D /* Pods_PhotoAssassin.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,12 +76,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				453592BAE7D47041D989B3DA /* Pods_PhotoAssassinTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		013CD327B8D7F500DD63645C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				315972CCCCFF02A2AF2F368F /* Pods_PhotoAssassin.framework */,
+				DCEE01467EB47FB4FBF4B858 /* Pods_PhotoAssassinTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		2A1DD4E21F38A09700712195 /* Launch */ = {
 			isa = PBXGroup;
 			children = (
@@ -83,22 +104,24 @@
 			isa = PBXGroup;
 			children = (
 				55F50BE321404BDD00FAC039 /* Readme.md */,
-				2A1E77351F384BFC006C84D4 /* Photo Assassin */,
-				2A1E774A1F384BFD006C84D4 /* Photo AssassinTests */,
+				2A1E77351F384BFC006C84D4 /* PhotoAssassin */,
+				2A1E774A1F384BFD006C84D4 /* PhotoAssassinTests */,
 				2A1E77341F384BFC006C84D4 /* Products */,
+				8E726112DE9087B6EBA3D998 /* Pods */,
+				013CD327B8D7F500DD63645C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
 		2A1E77341F384BFC006C84D4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				2A1E77331F384BFC006C84D4 /* Photo Assassin.app */,
-				2A1E77471F384BFD006C84D4 /* Photo AssassinTests.xctest */,
+				2A1E77331F384BFC006C84D4 /* PhotoAssassin.app */,
+				2A1E77471F384BFD006C84D4 /* PhotoAssassinTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		2A1E77351F384BFC006C84D4 /* Photo Assassin */ = {
+		2A1E77351F384BFC006C84D4 /* PhotoAssassin */ = {
 			isa = PBXGroup;
 			children = (
 				C90395231FC622D2006F1DC0 /* main.swift */,
@@ -109,17 +132,17 @@
 				2AB31D9F1F38741400B7D1F3 /* Modules */,
 				2AFB310A1F385A20009C4586 /* Helpers */,
 			);
-			path = "Photo Assassin";
+			path = PhotoAssassin;
 			sourceTree = "<group>";
 		};
-		2A1E774A1F384BFD006C84D4 /* Photo AssassinTests */ = {
+		2A1E774A1F384BFD006C84D4 /* PhotoAssassinTests */ = {
 			isa = PBXGroup;
 			children = (
-				2A9222841F387B1D00A648E6 /* Photo AssassinTests-Bridging-Header.h */,
+				2A9222841F387B1D00A648E6 /* PhotoAssassinTests-Bridging-Header.h */,
 				2A1E774D1F384BFD006C84D4 /* Info.plist */,
 				C90395251FC62399006F1DC0 /* TestsAppDelegate.swift */,
 			);
-			path = "Photo AssassinTests";
+			path = PhotoAssassinTests;
 			sourceTree = "<group>";
 		};
 		2AB31D9E1F38740A00B7D1F3 /* Models */ = {
@@ -223,32 +246,48 @@
 			path = Generated;
 			sourceTree = "<group>";
 		};
+		8E726112DE9087B6EBA3D998 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C52A4E7F78583ED8C2BBE440 /* Pods-PhotoAssassin.debug.xcconfig */,
+				DE2B0C473DF0611EF21D8951 /* Pods-PhotoAssassin.staging.xcconfig */,
+				45AEA0686ECF05A538683431 /* Pods-PhotoAssassin.release.xcconfig */,
+				CC236DEB12294412F387B307 /* Pods-PhotoAssassinTests.debug.xcconfig */,
+				CD5823A07B8C53621396FBF3 /* Pods-PhotoAssassinTests.staging.xcconfig */,
+				2C2BC69BEA45C045090EE25D /* Pods-PhotoAssassinTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		2A1E77321F384BFC006C84D4 /* Photo Assassin */ = {
+		2A1E77321F384BFC006C84D4 /* PhotoAssassin */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2A1E77501F384BFD006C84D4 /* Build configuration list for PBXNativeTarget "Photo Assassin" */;
+			buildConfigurationList = 2A1E77501F384BFD006C84D4 /* Build configuration list for PBXNativeTarget "PhotoAssassin" */;
 			buildPhases = (
+				9B2D92CF92F55C5A01502C38 /* [CP] Check Pods Manifest.lock */,
 				553FC23A2140470C001D9362 /* R.swift */,
 				2A1E772F1F384BFC006C84D4 /* Sources */,
 				FC9CA61F1F83C1B700B8EB94 /* SwiftLint */,
 				2A1E77301F384BFC006C84D4 /* Frameworks */,
 				2A1E77311F384BFC006C84D4 /* Resources */,
+				49E5CF9B1AEE6DDDB18C9E94 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = "Photo Assassin";
-			productName = "Photo Assassin";
-			productReference = 2A1E77331F384BFC006C84D4 /* Photo Assassin.app */;
+			name = PhotoAssassin;
+			productName = PhotoAssassin;
+			productReference = 2A1E77331F384BFC006C84D4 /* PhotoAssassin.app */;
 			productType = "com.apple.product-type.application";
 		};
-		2A1E77461F384BFD006C84D4 /* Photo AssassinTests */ = {
+		2A1E77461F384BFD006C84D4 /* PhotoAssassinTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2A1E77531F384BFD006C84D4 /* Build configuration list for PBXNativeTarget "Photo AssassinTests" */;
+			buildConfigurationList = 2A1E77531F384BFD006C84D4 /* Build configuration list for PBXNativeTarget "PhotoAssassinTests" */;
 			buildPhases = (
+				F88C1FBD522CC96E243681D0 /* [CP] Check Pods Manifest.lock */,
 				2A1E77431F384BFD006C84D4 /* Sources */,
 				2A1E77441F384BFD006C84D4 /* Frameworks */,
 				2A1E77451F384BFD006C84D4 /* Resources */,
@@ -258,9 +297,9 @@
 			dependencies = (
 				2A1E77491F384BFD006C84D4 /* PBXTargetDependency */,
 			);
-			name = "Photo AssassinTests";
-			productName = "Photo AssassinTests";
-			productReference = 2A1E77471F384BFD006C84D4 /* Photo AssassinTests.xctest */;
+			name = PhotoAssassinTests;
+			productName = PhotoAssassinTests;
+			productReference = 2A1E77471F384BFD006C84D4 /* PhotoAssassinTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -283,7 +322,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 2A1E772E1F384BFC006C84D4 /* Build configuration list for PBXProject "Photo Assassin" */;
+			buildConfigurationList = 2A1E772E1F384BFC006C84D4 /* Build configuration list for PBXProject "PhotoAssassin" */;
 			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -296,8 +335,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				2A1E77321F384BFC006C84D4 /* Photo Assassin */,
-				2A1E77461F384BFD006C84D4 /* Photo AssassinTests */,
+				2A1E77321F384BFC006C84D4 /* PhotoAssassin */,
+				2A1E77461F384BFD006C84D4 /* PhotoAssassinTests */,
 			);
 		};
 /* End PBXProject section */
@@ -324,6 +363,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		49E5CF9B1AEE6DDDB18C9E94 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-PhotoAssassin/Pods-PhotoAssassin-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/R.swift.Library/Rswift.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Rswift.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PhotoAssassin/Pods-PhotoAssassin-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		553FC23A2140470C001D9362 /* R.swift */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -334,11 +395,55 @@
 			);
 			name = R.swift;
 			outputPaths = (
-				"$SRCROOT/Photo Assassin/Resources/Generated/R.generated.swift",
+				"$SRCROOT/PhotoAssassin/Resources/Generated/R.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$PODS_ROOT/R.swift/rswift\" generate \"$SRCROOT/Photo Assassin/Resources/Generated/R.generated.swift\"\n";
+			shellScript = "\"$PODS_ROOT/R.swift/rswift\" generate \"$SRCROOT/PhotoAssassin/Resources/Generated/R.generated.swift\"\n";
+		};
+		9B2D92CF92F55C5A01502C38 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PhotoAssassin-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F88C1FBD522CC96E243681D0 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PhotoAssassinTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		FC9CA61F1F83C1B700B8EB94 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -385,7 +490,7 @@
 /* Begin PBXTargetDependency section */
 		2A1E77491F384BFD006C84D4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2A1E77321F384BFC006C84D4 /* Photo Assassin */;
+			target = 2A1E77321F384BFC006C84D4 /* PhotoAssassin */;
 			targetProxy = 2A1E77481F384BFD006C84D4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -416,12 +521,16 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
@@ -429,10 +538,6 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -476,12 +581,16 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
@@ -489,10 +598,6 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -517,9 +622,10 @@
 		};
 		2A1E77511F384BFD006C84D4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C52A4E7F78583ED8C2BBE440 /* Pods-PhotoAssassin.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = "Photo Assassin/SupportingFiles/Info.plist";
+				INFOPLIST_FILE = PhotoAssassin/SupportingFiles/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "$(inherited) -Xfrontend -warn-long-expression-type-checking=500";
@@ -532,9 +638,10 @@
 		};
 		2A1E77521F384BFD006C84D4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 45AEA0686ECF05A538683431 /* Pods-PhotoAssassin.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = "Photo Assassin/SupportingFiles/Info.plist";
+				INFOPLIST_FILE = PhotoAssassin/SupportingFiles/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -547,36 +654,38 @@
 		};
 		2A1E77541F384BFD006C84D4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CC236DEB12294412F387B307 /* Pods-PhotoAssassinTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
-				INFOPLIST_FILE = "Photo AssassinTests/Info.plist";
+				INFOPLIST_FILE = PhotoAssassinTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "Photo AssassinTests/Photo AssassinTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "PhotoAssassinTests/PhotoAssassinTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Photo Assassin.app/Photo Assassin";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PhotoAssassin.app/PhotoAssassin";
 			};
 			name = Debug;
 		};
 		2A1E77551F384BFD006C84D4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2C2BC69BEA45C045090EE25D /* Pods-PhotoAssassinTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
-				INFOPLIST_FILE = "Photo AssassinTests/Info.plist";
+				INFOPLIST_FILE = PhotoAssassinTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "Photo AssassinTests/Photo AssassinTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "PhotoAssassinTests/PhotoAssassinTests-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Photo Assassin.app/Photo Assassin";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PhotoAssassin.app/PhotoAssassin";
 			};
 			name = Release;
 		};
@@ -594,12 +703,16 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
@@ -607,10 +720,6 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -642,9 +751,10 @@
 		};
 		2ABEE6D01F387C5D00531205 /* Staging */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DE2B0C473DF0611EF21D8951 /* Pods-PhotoAssassin.staging.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = "Photo Assassin/SupportingFiles/Info.plist";
+				INFOPLIST_FILE = PhotoAssassin/SupportingFiles/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -657,26 +767,27 @@
 		};
 		2ABEE6D11F387C5D00531205 /* Staging */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CD5823A07B8C53621396FBF3 /* Pods-PhotoAssassinTests.staging.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
-				INFOPLIST_FILE = "Photo AssassinTests/Info.plist";
+				INFOPLIST_FILE = PhotoAssassinTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "Photo AssassinTests/Photo AssassinTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "PhotoAssassinTests/PhotoAssassinTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Photo Assassin.app/Photo Assassin";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PhotoAssassin.app/PhotoAssassin";
 			};
 			name = Staging;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		2A1E772E1F384BFC006C84D4 /* Build configuration list for PBXProject "Photo Assassin" */ = {
+		2A1E772E1F384BFC006C84D4 /* Build configuration list for PBXProject "PhotoAssassin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2A1E774E1F384BFD006C84D4 /* Debug */,
@@ -686,7 +797,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2A1E77501F384BFD006C84D4 /* Build configuration list for PBXNativeTarget "Photo Assassin" */ = {
+		2A1E77501F384BFD006C84D4 /* Build configuration list for PBXNativeTarget "PhotoAssassin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2A1E77511F384BFD006C84D4 /* Debug */,
@@ -696,7 +807,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2A1E77531F384BFD006C84D4 /* Build configuration list for PBXNativeTarget "Photo AssassinTests" */ = {
+		2A1E77531F384BFD006C84D4 /* Build configuration list for PBXNativeTarget "PhotoAssassinTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2A1E77541F384BFD006C84D4 /* Debug */,

--- a/PhotoAssassin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/PhotoAssassin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Photo Assassin.xcodeproj">
+      location = "self:PhotoAssassin.xcodeproj">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
Currently, the build instructions as specified in README.md do not successfully build the project. This commit fixes that issue by changing metadata in CocoaPods and XCode data files to match the project's actual structure.

#### Steps to reproduce the bug
1. `$ git clone https://github.com/michiganhackers/photo-assassin-ios-app.git`
2. `$ cd photo-assassin-ios-app`
3. `$ bundle exec pod install`
The final command will fail with the error "Unable to find a target named \`PhotoAssassin\`..."

#### Why the issue occurs
The .swiftlint.yml, project.pbxproj, and contents.xcworkspacedata files all contain paths that specify the locations of various source files and other files needed for building the project. Currently, each of these paths starts with `Photo Assassin/`. However, the directory `Photo Assassin` does not exist; the files are actually in `PhotoAssassin/`.

This commit renames all paths in those files to begin with `PhotoAssassin/`.